### PR TITLE
please incorporate the rest of my fork

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+While the original author (Originalseed) appears to be unreachable,
+according to https://www.opendesktop.org/p/1080259/ the license of this
+theme (as well as its Emerald, Cinnamon, MDM/GDM and Metacity versions)
+is GPLv2 or later.
+
+Metacity support is based on GPLed version of RoyaleVSQ Black by Rob Louw.

--- a/gtk-3.20/gtk.css
+++ b/gtk-3.20/gtk.css
@@ -401,8 +401,8 @@ separator:hover,
 }
 
 button separator {
-    -GtkWidget-separator-width: 2px;
-	-GtkWidget-separator-height: 2;
+    min-width: 2px;
+    min-height: 2px;
 	border:solid;
     background-image: url("darkelements/line-v.png");
 	background-size: 100% 100%;
@@ -1303,8 +1303,7 @@ button separator {
 }
 menuitem separator,
 .menuitem .separator {
-	-GtkWidget-wide-separators: true;
-	-GtkWidget-separator-height: 2px;
+	min-height: 2px;
 	border:solid;
     border-image: url("darkelements/line-h.png") 0 0 2 0  stretch ;
 	border-width:  0 0 2px 0;
@@ -1318,8 +1317,7 @@ separator:hover:backdrop,
 .separator:hover,
 .separator:backdrop,
 .separator:hover:backdrop {
-	-GtkWidget-wide-separators: true;
-	-GtkWidget-separator-height: 2px;
+	min-height: 2px;
 	border:solid;
     border-image: url("darkelements/line-h.png") 0 0 2 0  stretch ;
 	border-width:  0 0 2px 0;
@@ -1333,7 +1331,6 @@ separator.horizontal:hover:backdrop,
 .separator.horizontal:hover,
 .separator.horizontal:backdrop,
 .separator.horizontal:hover:backdrop {
-	-GtkWidget-wide-separators: true;
 border:solid;
     background-image: url("darkelements/line-h.png");
 	background-size: 100% 100%;
@@ -1347,7 +1344,6 @@ border:solid;
 .separator.vertical:hover,
 .separator.vertical:backdrop,
 .separator.vertical:hover:backdrop {
-	-GtkWidget-wide-separators: true;
 border:solid;
     background-image: url("darkelements/line-v.png");
 	background-size: 100% 100%;

--- a/gtk-3.20/gtk.css
+++ b/gtk-3.20/gtk.css
@@ -2311,10 +2311,6 @@ scrollbar {
     -GtkScrollbar-has-forward-stepper: true;
     background-image: none;
     border-style: solid;
-    -GtkRange-trough-border: 0;
-    
-    -GtkRange-slider-width: 16px;
-    -GtkRange-stepper-size: 16px;
 }
 
 scrollbar.vertical {
@@ -2326,7 +2322,7 @@ scrollbar.horizontal {
 }
 
 scrollbar trough {
-
+    margin: 0;
 }
 
 scrolledwindow junction {
@@ -2454,6 +2450,7 @@ scrollbar.vertical .slider:hover {
 
 scrollbar.horizontal slider,
 scrollbar.horizontal .slider {
+    min-height: 16px;
     border: solid;
  	border-image: url("darkelements/scrollbars/slider-horiz.png") 8 2 8 2 / 8px 2px 8px 2px stretch stretch;
     border-width: 8px 2px;


### PR DESCRIPTION
While you were gone, I took over.  There's not many changes since what you already merged, but it'd be nice if you could pull in everything.  Because of git history reasons, doing this as a merge would be preferred.  You could then massage the LICENSE file further.

The remaining fixes get rid of a spam of warnings in the version of GTK Ubuntu 18.04 ships.  Positive lines convert the removed syntax to what the docs say is a replacement, but as far as I know they're redundant with defaults/inherits already.

I also have some uncommitted WIP: almost all image assets in gtk-3.20 are unmodified copies of those in gtk-3.0, the on-disk size of the theme can be greatly reduced by replacing them with symlinks.  If you want this as well, which direction should the symlinks go?

I looked into darkmint as well, but that's a longer story.